### PR TITLE
Image Condition

### DIFF
--- a/resources/views/livewire/profile/update-image.blade.php
+++ b/resources/views/livewire/profile/update-image.blade.php
@@ -4,9 +4,11 @@
     <x-inputs.file key="image" required="required" />
 
     <div class="row">
-        <div class="offset-4 col-4">
-            <x-inputs.button text="Save" class="btn-success" />
-        </div>
+        @if($image != null)
+            <div class="offset-4 col-4">
+                <x-inputs.button text="Save" class="btn-success" />
+            </div>
+        @endif
 
         <div class="col-4">
             <button type="button" class="btn btn-outline-secondary btn-block" x-on:click="show = false">Cancel</button>


### PR DESCRIPTION
If this condition is not set. after immediately updating the image if someone submit , the $image variable stays null. so it throws an error